### PR TITLE
Fix Scroll Carousel in Discover Page

### DIFF
--- a/src/pages/Discover.tsx
+++ b/src/pages/Discover.tsx
@@ -268,7 +268,15 @@ export function Discover() {
     }
   }, [movieWidth]);
 
+  const browser = !!window.chrome; // detect chromium browser
+  let isScrolling = false;
+
   function handleWheel(e: React.WheelEvent, categorySlug: string) {
+    if (isScrolling) {
+      return;
+    }
+
+    isScrolling = true;
     const carousel = carouselRefs.current[categorySlug];
     if (carousel) {
       const movieElements = carousel.getElementsByTagName("a");
@@ -279,6 +287,15 @@ export function Discover() {
           scrollCarousel(categorySlug, "right");
         }
       }
+    }
+
+    if (browser) {
+      setTimeout(() => {
+        isScrolling = false;
+      }, 345); // disable scrolling after 345 milliseconds for chromium-based browsers
+    } else {
+      // immediately reset isScrolling for non-chromium browsers
+      isScrolling = false;
     }
   }
 

--- a/src/pages/Discover.tsx
+++ b/src/pages/Discover.tsx
@@ -226,7 +226,6 @@ export function Discover() {
     genres.forEach((genre) => fetchMoviesForGenre(genre.id));
   }, [genres]);
 
-  // Update the scrollCarousel function to use the new ref map
   function scrollCarousel(categorySlug: string, direction: string) {
     const carousel = carouselRefs.current[categorySlug];
     if (carousel) {
@@ -237,22 +236,7 @@ export function Discover() {
         const scrollAmount = movieWidth * visibleMovies * 0.69; // Silly number :3
 
         if (direction === "left") {
-          if (carousel.scrollLeft <= 5) {
-            carousel.scrollBy({
-              left: carousel.scrollWidth,
-              behavior: "smooth",
-            }); // Scroll to the end
-          } else {
-            carousel.scrollBy({ left: -scrollAmount, behavior: "smooth" });
-          }
-        } else if (
-          carousel.scrollLeft + carousel.offsetWidth + 5 >=
-          carousel.scrollWidth
-        ) {
-          carousel.scrollBy({
-            left: -carousel.scrollWidth,
-            behavior: "smooth",
-          }); // Scroll to the beginning
+          carousel.scrollBy({ left: -scrollAmount, behavior: "smooth" });
         } else {
           carousel.scrollBy({ left: scrollAmount, behavior: "smooth" });
         }
@@ -284,41 +268,21 @@ export function Discover() {
     }
   }, [movieWidth]);
 
-  let isScrolling = false;
   function handleWheel(e: React.WheelEvent, categorySlug: string) {
-    if (isScrolling) {
-      return;
-    }
-
-    isScrolling = true;
-
     const carousel = carouselRefs.current[categorySlug];
-    if (carousel && !e.deltaX) {
+    if (carousel) {
       const movieElements = carousel.getElementsByTagName("a");
       if (movieElements.length > 0) {
-        const posterWidth = movieElements[0].offsetWidth;
-        const visibleMovies = Math.floor(carousel.offsetWidth / posterWidth);
-        const scrollAmount = posterWidth * visibleMovies * 0.62;
         if (e.deltaY < 5) {
-          carousel.scrollBy({ left: -scrollAmount, behavior: "smooth" });
+          scrollCarousel(categorySlug, "left");
         } else {
-          carousel.scrollBy({ left: scrollAmount, behavior: "smooth" });
+          scrollCarousel(categorySlug, "right");
         }
       }
     }
-
-    setTimeout(() => {
-      isScrolling = false;
-    }, 345); // Disable scrolling every 3 milliseconds after interaction (only for mouse wheel doe)
   }
 
   const [isHovered, setIsHovered] = useState(false);
-
-  useEffect(() => {
-    if (!isHovered) {
-      document.body.style.overflow = "auto";
-    }
-  }, [isHovered]);
 
   const handleMouseEnter = () => {
     document.body.style.overflow = "hidden";
@@ -328,6 +292,12 @@ export function Discover() {
   const handleMouseLeave = () => {
     setIsHovered(false);
   };
+
+  useEffect(() => {
+    if (!isHovered) {
+      document.body.style.overflow = "auto";
+    }
+  }, [isHovered]);
 
   function renderMovies(medias: Media[], category: string, isTVShow = false) {
     const categorySlug = `${category.toLowerCase().replace(/ /g, "-")}${Math.random()}`; // Convert the category to a slug


### PR DESCRIPTION
I had noticed that, despite PR #24, the scroll carousel present on the discover page was still janky. I improved the code for mostly everything related to the scroll carousel and, in turn, fixed the jankiness that was present. I have hosted the fix [here](https://darling-melba-9d0223.netlify.app/discover) for preview.

**EDIT:** I thought the jankiness was present in all browsers but it turned out it was only present in non-chromium browsers (ex: Firefox). In my 2nd commit, I added a check utilizing the ``!!window.chrome`` method where ``setTimeout`` will only be functional when a user is on a chromium-based browser. 

When ``setTimeout`` is functional regardless of check, users on non-chromium browsers will have a janky experience. If we remove ``setTimeout``, it's vice versa. 

 - [x] I have read and agreed to the [code of conduct](https://github.com/sussy-code/smov/blob/dev/.github/CODE_OF_CONDUCT.md).
 - [x] I have read and complied with the [contributing guidelines](https://github.com/sussy-code/smov/blob/dev/.github/CONTRIBUTING.md).
 - [x] I have tested all of my changes.
 - Enter discord user: `k9rbo` 