### PR TITLE
Correctly Reset Body Overflow

### DIFF
--- a/src/pages/Discover.tsx
+++ b/src/pages/Discover.tsx
@@ -300,20 +300,14 @@ export function Discover() {
   }
 
   const [isHovered, setIsHovered] = useState(false);
-
-  const handleMouseEnter = () => {
-    document.body.style.overflow = "hidden";
-    setIsHovered(true);
-  };
-
-  const handleMouseLeave = () => {
-    setIsHovered(false);
-  };
+  const toggleHover = (isHovering: boolean) => setIsHovered(isHovering);
 
   useEffect(() => {
-    if (!isHovered) {
+    document.body.style.overflow = isHovered ? "hidden" : "auto";
+
+    return () => {
       document.body.style.overflow = "auto";
-    }
+    };
   }, [isHovered]);
 
   function renderMovies(medias: Media[], category: string, isTVShow = false) {
@@ -344,8 +338,8 @@ export function Discover() {
           ref={(el) => {
             carouselRefs.current[categorySlug] = el;
           }}
-          onMouseEnter={handleMouseEnter}
-          onMouseLeave={handleMouseLeave}
+          onMouseEnter={() => toggleHover(true)}
+          onMouseLeave={() => toggleHover(false)}
           onWheel={(e) => handleWheel(e, categorySlug)}
         >
           {medias


### PR DESCRIPTION
This PR ensures that the body overflow style is correctly reset to "auto" when a user stops hovering over the scroll carousel. 

Previously, the body overflow was only reset when the user was actively on the discover page and moved their mouse off the carousel, causing the overflow to remain hidden when navigating away (such as clicking a movie to watch and then "Back to home"). If the body overflow were to be set to "hidden", this effectively means that you cannot scroll. 

[preview](https://fix-overflow--darling-melba-9d0223.netlify.app/)

![chrome_oEt7MHwx9l](https://github.com/sussy-code/smov/assets/107429396/b05195d8-a1a2-4847-9818-8d0f0b2065ba)

 - [x] I have read and agreed to the [code of conduct](https://github.com/sussy-code/smov/blob/dev/.github/CODE_OF_CONDUCT.md).
 - [x] I have read and complied with the [contributing guidelines](https://github.com/sussy-code/smov/blob/dev/.github/CONTRIBUTING.md).
 - [x] I have tested all of my changes.