### PR TITLE
Add 20s timer to prevent scraping freeze

### DIFF
--- a/src/hooks/useProviderScrape.tsx
+++ b/src/hooks/useProviderScrape.tsx
@@ -160,7 +160,8 @@ export function useScrape() {
   const preferredSourceOrder = usePreferencesStore((s) => s.sourceOrder);
 
   const startScraping = useCallback(
-    async (media: ScrapeMedia) => {
+    // Change: Added startIndex parameter with default value 0
+    async (media: ScrapeMedia, startIndex: number = 0) => {
       const providerApiUrl = getLoadbalancedProviderApiUrl();
       if (providerApiUrl && !isExtensionActiveCached()) {
         startScrape();
@@ -184,7 +185,8 @@ export function useScrape() {
       const providers = getProviders();
       const output = await providers.runAll({
         media,
-        sourceOrder: preferredSourceOrder,
+        // Change: Use slice to start from startIndex
+        sourceOrder: preferredSourceOrder.slice(startIndex),
         events: {
           init: initEvent,
           start: startEvent,

--- a/src/hooks/useProviderScrape.tsx
+++ b/src/hooks/useProviderScrape.tsx
@@ -160,8 +160,7 @@ export function useScrape() {
   const preferredSourceOrder = usePreferencesStore((s) => s.sourceOrder);
 
   const startScraping = useCallback(
-    // Change: Added startIndex parameter with default value 0
-    async (media: ScrapeMedia, startIndex: number = 0) => {
+    async (media: ScrapeMedia) => {
       const providerApiUrl = getLoadbalancedProviderApiUrl();
       if (providerApiUrl && !isExtensionActiveCached()) {
         startScrape();
@@ -185,8 +184,7 @@ export function useScrape() {
       const providers = getProviders();
       const output = await providers.runAll({
         media,
-        // Change: Use slice to start from startIndex
-        sourceOrder: preferredSourceOrder.slice(startIndex),
+        sourceOrder: preferredSourceOrder,
         events: {
           init: initEvent,
           start: startEvent,

--- a/src/pages/parts/player/ScrapingPart.tsx
+++ b/src/pages/parts/player/ScrapingPart.tsx
@@ -91,7 +91,7 @@ export function ScrapingPart(props: ScrapingProps) {
         ),
       );
       props.onGetStream?.(output);
-      setVideoLoaded(true); // Add this line here
+      setVideoLoaded(true);
     })().catch(() => setFailedStartScrape(true));
   }, [startScraping, props, report, isMounted]);
 

--- a/src/pages/parts/player/ScrapingPart.tsx
+++ b/src/pages/parts/player/ScrapingPart.tsx
@@ -67,7 +67,7 @@ export function ScrapingPart(props: ScrapingProps) {
       if (!videoLoaded) {
         window.location.reload();
       }
-    }, 10000); // 10 seconds
+    }, 20000); // 20 seconds
 
     return () => clearTimeout(timer);
   }, [videoLoaded]);

--- a/src/pages/parts/player/ScrapingPart.tsx
+++ b/src/pages/parts/player/ScrapingPart.tsx
@@ -65,19 +65,28 @@ export function ScrapingPart(props: ScrapingProps) {
   useEffect(() => {
     const timer = setTimeout(() => {
       if (!videoLoaded) {
+        const currentIndex = sourceOrder.findIndex(
+          (s) => s.id === currentSource,
+        );
+        localStorage.setItem("lastScrapedIndex", (currentIndex + 1).toString());
         window.location.reload();
       }
     }, 10000); // 10 seconds
 
     return () => clearTimeout(timer);
-  }, [videoLoaded]);
+  }, [videoLoaded, sourceOrder, currentSource]);
 
   const started = useRef(false);
   useEffect(() => {
     if (started.current) return;
     started.current = true;
     (async () => {
-      const output = await startScraping(props.media);
+      const lastScrapedIndex = parseInt(
+        localStorage.getItem("lastScrapedIndex") || "0",
+        10,
+      );
+      localStorage.removeItem("lastScrapedIndex"); // Clear it after reading
+      const output = await startScraping(props.media, lastScrapedIndex);
       if (!isMounted()) return;
       props.onResult?.(
         resultRef.current.sources,
@@ -91,7 +100,7 @@ export function ScrapingPart(props: ScrapingProps) {
         ),
       );
       props.onGetStream?.(output);
-      setVideoLoaded(true); // Add this line here
+      setVideoLoaded(true);
     })().catch(() => setFailedStartScrape(true));
   }, [startScraping, props, report, isMounted]);
 

--- a/src/pages/parts/player/ScrapingPart.tsx
+++ b/src/pages/parts/player/ScrapingPart.tsx
@@ -40,6 +40,7 @@ export function ScrapingPart(props: ScrapingProps) {
   const { t } = useTranslation();
 
   const [videoLoaded, setVideoLoaded] = useState(false);
+  const [reloadCount, setReloadCount] = useState(0);
 
   const containerRef = useRef<HTMLDivElement | null>(null);
   const listRef = useRef<HTMLDivElement | null>(null);
@@ -64,13 +65,14 @@ export function ScrapingPart(props: ScrapingProps) {
 
   useEffect(() => {
     const timer = setTimeout(() => {
-      if (!videoLoaded) {
+      if (!videoLoaded && reloadCount < 2) {
+        setReloadCount(reloadCount + 1);
         window.location.reload();
       }
     }, 10000); // 10 seconds
 
     return () => clearTimeout(timer);
-  }, [videoLoaded]);
+  }, [videoLoaded, reloadCount]);
 
   const started = useRef(false);
   useEffect(() => {

--- a/src/pages/parts/player/ScrapingPart.tsx
+++ b/src/pages/parts/player/ScrapingPart.tsx
@@ -39,6 +39,8 @@ export function ScrapingPart(props: ScrapingProps) {
   const isMounted = useMountedState();
   const { t } = useTranslation();
 
+  const [videoLoaded, setVideoLoaded] = useState(false);
+
   const containerRef = useRef<HTMLDivElement | null>(null);
   const listRef = useRef<HTMLDivElement | null>(null);
   const [failedStartScrape, setFailedStartScrape] = useState<boolean>(false);
@@ -60,6 +62,16 @@ export function ScrapingPart(props: ScrapingProps) {
     };
   }, [sourceOrder, sources]);
 
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      if (!videoLoaded) {
+        window.location.reload();
+      }
+    }, 10000); // 10 seconds
+
+    return () => clearTimeout(timer);
+  }, [videoLoaded]);
+
   const started = useRef(false);
   useEffect(() => {
     if (started.current) return;
@@ -79,6 +91,7 @@ export function ScrapingPart(props: ScrapingProps) {
         ),
       );
       props.onGetStream?.(output);
+      setVideoLoaded(true); // Add this line here
     })().catch(() => setFailedStartScrape(true));
   }, [startScraping, props, report, isMounted]);
 
@@ -96,6 +109,13 @@ export function ScrapingPart(props: ScrapingProps) {
       className="h-full w-full relative dir-neutral:origin-top-left flex"
       ref={containerRef}
     >
+      {/* Add the new loading message here */}
+      {!videoLoaded && (
+        <div className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 text-center z-10">
+          <p>{t("player.turnstile.loadingVideo")}</p>
+          <p>{t("player.turnstile.autoRefresh")}</p>
+        </div>
+      )}
       {!sourceOrder || sourceOrder.length === 0 ? (
         <div className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 text-center flex flex-col justify-center z-0">
           <Loading className="mb-8" />

--- a/src/pages/parts/player/ScrapingPart.tsx
+++ b/src/pages/parts/player/ScrapingPart.tsx
@@ -40,7 +40,6 @@ export function ScrapingPart(props: ScrapingProps) {
   const { t } = useTranslation();
 
   const [videoLoaded, setVideoLoaded] = useState(false);
-  const [reloadCount, setReloadCount] = useState(0);
 
   const containerRef = useRef<HTMLDivElement | null>(null);
   const listRef = useRef<HTMLDivElement | null>(null);
@@ -65,14 +64,13 @@ export function ScrapingPart(props: ScrapingProps) {
 
   useEffect(() => {
     const timer = setTimeout(() => {
-      if (!videoLoaded && reloadCount < 2) {
-        setReloadCount(reloadCount + 1);
+      if (!videoLoaded) {
         window.location.reload();
       }
     }, 10000); // 10 seconds
 
     return () => clearTimeout(timer);
-  }, [videoLoaded, reloadCount]);
+  }, [videoLoaded]);
 
   const started = useRef(false);
   useEffect(() => {

--- a/src/pages/parts/player/ScrapingPart.tsx
+++ b/src/pages/parts/player/ScrapingPart.tsx
@@ -65,28 +65,19 @@ export function ScrapingPart(props: ScrapingProps) {
   useEffect(() => {
     const timer = setTimeout(() => {
       if (!videoLoaded) {
-        const currentIndex = sourceOrder.findIndex(
-          (s) => s.id === currentSource,
-        );
-        localStorage.setItem("lastScrapedIndex", (currentIndex + 1).toString());
         window.location.reload();
       }
     }, 10000); // 10 seconds
 
     return () => clearTimeout(timer);
-  }, [videoLoaded, sourceOrder, currentSource]);
+  }, [videoLoaded]);
 
   const started = useRef(false);
   useEffect(() => {
     if (started.current) return;
     started.current = true;
     (async () => {
-      const lastScrapedIndex = parseInt(
-        localStorage.getItem("lastScrapedIndex") || "0",
-        10,
-      );
-      localStorage.removeItem("lastScrapedIndex"); // Clear it after reading
-      const output = await startScraping(props.media, lastScrapedIndex);
+      const output = await startScraping(props.media);
       if (!isMounted()) return;
       props.onResult?.(
         resultRef.current.sources,
@@ -100,7 +91,7 @@ export function ScrapingPart(props: ScrapingProps) {
         ),
       );
       props.onGetStream?.(output);
-      setVideoLoaded(true);
+      setVideoLoaded(true); // Add this line here
     })().catch(() => setFailedStartScrape(true));
   }, [startScraping, props, report, isMounted]);
 

--- a/src/pages/parts/player/ScrapingPart.tsx
+++ b/src/pages/parts/player/ScrapingPart.tsx
@@ -109,13 +109,6 @@ export function ScrapingPart(props: ScrapingProps) {
       className="h-full w-full relative dir-neutral:origin-top-left flex"
       ref={containerRef}
     >
-      {/* Add the new loading message here */}
-      {!videoLoaded && (
-        <div className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 text-center z-10">
-          <p>{t("player.turnstile.loadingVideo")}</p>
-          <p>{t("player.turnstile.autoRefresh")}</p>
-        </div>
-      )}
       {!sourceOrder || sourceOrder.length === 0 ? (
         <div className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 text-center flex flex-col justify-center z-0">
           <Loading className="mb-8" />


### PR DESCRIPTION
20s is probably good enough. 

I do foresee some issues with sources that are too slow to respond. The page will just keep refreshing unless it either starts playing or the error shows. 
Not a permanent solution.

 - [x ] I have read and agreed to the [code of conduct](https://github.com/sussy-code/smov/blob/dev/.github/CODE_OF_CONDUCT.md).
 - [x ] I have read and complied with the [contributing guidelines](https://github.com/sussy-code/smov/blob/dev/.github/CONTRIBUTING.md).
 - [x ] I have tested all of my changes.

