### PR TITLE
Fix build error

### DIFF
--- a/src/pages/Discover.tsx
+++ b/src/pages/Discover.tsx
@@ -20,8 +20,9 @@ import {
 } from "@/utils/discover";
 
 import { SubPageLayout } from "./layouts/SubPageLayout";
-import { PageTitle } from "./parts/util/PageTitle";
 import { Icon, Icons } from "../components/Icon";
+// eslint-disable-next-line import/order
+import { PageTitle } from "./parts/util/PageTitle";
 
 export function Discover() {
   const { t } = useTranslation();


### PR DESCRIPTION
Logs from before:
```
22:49:16.575      24:1  error  `../components/Icon` import should occur before import of `./parts/util/PageTitle`  import/order
```

So I just reordered the imports.

 - [x] I have read and agreed to the [code of conduct](https://github.com/sussy-code/smov/blob/dev/.github/CODE_OF_CONDUCT.md).
 - [x] I have read and complied with the [contributing guidelines](https://github.com/sussy-code/smov/blob/dev/.github/CONTRIBUTING.md).
 - [x] I have tested all of my changes.
 - Enter discord user: `.pasithea` (we require this for the contributor role)
