### PR TITLE
Make scraping buttons stay on top

### DIFF
--- a/src/pages/parts/player/PlayerPart.tsx
+++ b/src/pages/parts/player/PlayerPart.tsx
@@ -7,6 +7,8 @@ import { useIsMobile } from "@/hooks/useIsMobile";
 import { PlayerMeta, playerStatus } from "@/stores/player/slices/source";
 import { usePlayerStore } from "@/stores/player/store";
 
+import { ScrapingPartInterruptButton } from "./ScrapingPart";
+
 export interface PlayerPartProps {
   children?: ReactNode;
   backUrl: string;
@@ -80,7 +82,10 @@ export function PlayerPart(props: PlayerPartProps) {
       </Player.TopControls>
 
       <Player.BottomControls show={showTargets}>
-        <div className="flex items-center space-x-3">
+        <div className="flex items-center justify-center space-x-3 h-full">
+          {status === playerStatus.SCRAPING ? (
+            <ScrapingPartInterruptButton />
+          ) : null}
           {status === playerStatus.PLAYING ? (
             <>
               {isMobile ? <Player.Time short /> : null}

--- a/src/pages/parts/player/ScrapingPart.tsx
+++ b/src/pages/parts/player/ScrapingPart.tsx
@@ -151,25 +151,32 @@ export function ScrapingPart(props: ScrapingProps) {
             </div>
           );
         })}
-        <div className="flex gap-3 pb-3">
-          <Button
-            href="/"
-            theme="secondary"
-            padding="md:px-17 p-3"
-            className="mt-6"
-          >
-            {t("notFound.goHome")}
-          </Button>
-          <Button
-            onClick={() => window.location.reload()}
-            theme="purple"
-            padding="md:px-17 p-3"
-            className="mt-6"
-          >
-            {t("notFound.reloadButton")}
-          </Button>
-        </div>
       </div>
+    </div>
+  );
+}
+
+export function ScrapingPartInterruptButton() {
+  const { t } = useTranslation();
+
+  return (
+    <div className="flex gap-3 pb-3">
+      <Button
+        href="/"
+        theme="secondary"
+        padding="md:px-17 p-3"
+        className="mt-6"
+      >
+        {t("notFound.goHome")}
+      </Button>
+      <Button
+        onClick={() => window.location.reload()}
+        theme="purple"
+        padding="md:px-17 p-3"
+        className="mt-6"
+      >
+        {t("notFound.reloadButton")}
+      </Button>
     </div>
   );
 }


### PR DESCRIPTION
Moves "Back to home" and "Try again" buttons to top and persist location.

<img width="400" alt="Screenshot 2024-09-11 at 11 51 51 PM" src="https://github.com/user-attachments/assets/3302c07f-53f3-4db1-80aa-79f587892f72">
<img width="400" alt="Screenshot 2024-09-11 at 11 54 05 PM" src="https://github.com/user-attachments/assets/f4adead2-b995-4565-9e64-a6df1d771279">

 - [x] I have read and agreed to the [code of conduct](https://github.com/sussy-code/smov/blob/dev/.github/CODE_OF_CONDUCT.md).
 - [x] I have read and complied with the [contributing guidelines](https://github.com/sussy-code/smov/blob/dev/.github/CONTRIBUTING.md).
 - [x] I have tested all of my changes.
 - Enter discord user: `.pasithea` (we require this for the contributor role)
