### PR TITLE
Fix slider bug for subtitle styles in settings

### DIFF
--- a/src/pages/parts/settings/CaptionsPart.tsx
+++ b/src/pages/parts/settings/CaptionsPart.tsx
@@ -100,7 +100,7 @@ export function CaptionsPart(props: {
             onChange={(v) =>
               props.setStyling({ ...props.styling, backgroundBlur: v / 100 })
             }
-            value={props.styling.backgroundBlur * 1}
+            value={props.styling.backgroundBlur * 100}
             textTransformer={(s) => `${s}%`}
           />
           <CaptionSetting


### PR DESCRIPTION
The slider was broken, now it works